### PR TITLE
Add clarification to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ This confirms that there is a symlink to start the tailscale service.
 
 At this point, you should have:
 * tailscale stubs in `/usr/bin`: `ls /urs/bin/tailscale*`
-  * tailscale 1218 bytes
-  * tailscaled 1086 bytes
+  * tailscale xxxx bytes
+  * tailscaled xxxx bytes
 * tailscale service init script in `/etc/init.d/tailscale`: `ls /etc/init.d/tailscale`
 * symlink `/etc/rc.d/S*tailscale`: `ls /etc/rc.d/S*tailscale*`
 
@@ -48,5 +48,6 @@ If you log back into your router, the first time you run a command like `tailsca
 6. To update the version of tailscale, grab the latest version [here](https://pkgs.tailscale.com/stable/#static) of the form `1.2.10_mips` and replace the same in `/usr/bin/tailscale` and `/usr/bin/tailscaled`: `version="1.2.10_mips"`.
 
 Note: You need to have atleast 11+16 = ~27 MB of free space in `/tmp` (which is usually in RAM) to be able to use this.
+
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-su# Tailscale on OpenWRT
+# Tailscale on OpenWRT
 
 1. Extract the contents of root to your filesystem root:
 ```
@@ -48,4 +48,5 @@ If you log back into your router, the first time you run a command like `tailsca
 6. To update the version of tailscale, grab the latest version [here](https://pkgs.tailscale.com/stable/#static) of the form `1.2.10_mips` and replace the same in `/usr/bin/tailscale` and `/usr/bin/tailscaled`: `version="1.2.10_mips"`.
 
 Note: You need to have atleast 11+16 = ~27 MB of free space in `/tmp` (which is usually in RAM) to be able to use this.
+
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tailscale on OpenWRT
+su# Tailscale on OpenWRT
 
 1. Extract the contents of root to your filesystem root:
 ```
@@ -30,9 +30,22 @@ Verify by looking for an entry here:
 ```
 ls /etc/rc.d/S*tailscale*
 ```
+This confirms that there is a symlink to start the tailscale service.
+
+At this point, you should have:
+* tailscale stubs in `/usr/bin`: `ls /urs/bin/tailscale*`
+  * tailscale 1218 bytes
+  * tailscaled 1086 bytes
+* tailscale service init script in `/etc/init.d/tailscale`: `ls /etc/init.d/tailscale`
+* symlink `/etc/rc.d/S*tailscale`: `ls /etc/rc.d/S*tailscale*`
+
+If so, go ahead and...
 
 5. Reboot the router and verify that it shows up online on the [Tailscale Admin portal](https://login.tailscale.com/admin/machines).
+
+If you log back into your router, the first time you run a command like `tailscale status` the stub will download the `tailscale` binary.  The `tailscaled` daemon should have already been downloaded by the service start.
 
 6. To update the version of tailscale, grab the latest version [here](https://pkgs.tailscale.com/stable/#static) of the form `1.2.10_mips` and replace the same in `/usr/bin/tailscale` and `/usr/bin/tailscaled`: `version="1.2.10_mips"`.
 
 Note: You need to have atleast 11+16 = ~27 MB of free space in `/tmp` (which is usually in RAM) to be able to use this.
+


### PR DESCRIPTION
Following this comment https://github.com/adyanth/openwrt-tailscale-enabler/issues/54#issuecomment-3717255290, and a lot of less than smooth upgrades / reboots, I finally realised that I hadn't been diligent in re-setting up tailscale when I upgraded my router's firmware.

Your comment in #54 helped me realise that I hadn't properly checked if tailscale was properly enabled to start on boot, so I've added it to my post-firmware upgrade script, and thought I'd contribute a suggested enhancement to the readme for your consideration.

Even though I have a router that has enough storage to install tailscale, I still prefer to install to RAM, so thanks for your installer.